### PR TITLE
Change package management in ovirt-common

### DIFF
--- a/examples/inventory/group_vars/all.yml
+++ b/examples/inventory/group_vars/all.yml
@@ -1,0 +1,32 @@
+---
+## This file allows pass yaml variables to playbooks
+# defining variables in inventory is not prefered practise
+#   - http://docs.ansible.com/ansible/intro_inventory.html#splitting-out-host-and-group-specific-data
+# you can specify yaml variables in following files:
+# 1) ./host_vars/{host_name}      - for specific host
+# 2) ./group_vars/{group_name}    - for specific group
+# 3) ./group_vars/all             - for all hosts
+# where './foo.inv' is direction to your inventory
+
+# this file has classic YAML structure
+
+# download repo file
+ovirt_repo_file:
+  -
+    url: http://example.com/repository1.repo
+    name: example.repo # default same as remote
+    force: yes # default no
+    # If force=yes, download the file and replace local file if the contents change.
+    # If force=no, the file will only be downloaded if the destination does not exist.
+  -
+    url: http://example.com/repository2.repo
+
+# create repo file
+ovirt_repo:
+  -
+    name: repo1
+    url: http://example.com/path/to/packages
+    enabled: yes # defualt yes
+
+# install from rpm
+ovirt_rpm_repo: http://example.com/ovirt.rpm

--- a/examples/inventory/install_engine.inv
+++ b/examples/inventory/install_engine.inv
@@ -14,19 +14,8 @@ ovirt_engine_version=4.0
 ## Engine Repositories ##
 # Set repositories for installing engine
 # Use either ovirt_rpm_repo or ovirt_dependency_repo, ovirt_rpm_repo
-#   ovirt_repo - URL of main repository file
-#   ovirt_dependency_repo - URL of dependency repository file
-#   ovirt_rpm_repo - URL of RPM package which contains repository files
-#
-#  Example:
-#    ovirt_repo=http://to.somewhere
-#    ovirt_dependency_repo=http://to.somewhere
-#  OR
-#    ovirt_rpm_repo=http://to.somewhere.rpm
-#
-ovirt_repo=fill me
-ovirt_dependency_repo=fill me
-#ovirt_rpm_repo=fill me
+#   for more information see:
+#     'ovirt-ansible/examples/inventory/group_vars/all.yml'
 
 ## Data Warehouse DWH ##
 # Install DWH together with engine as a local installation
@@ -117,5 +106,3 @@ ovirt_engine_db_password=fill me
 ovirt_engine_dwh_db_name=ovirt_engine_history
 ovirt_engine_dwh_db_user=ovirt_engine_history
 ovirt_engine_dwh_db_password=fill me
-
-

--- a/examples/inventory/provision_hypervisor.inv
+++ b/examples/inventory/provision_hypervisor.inv
@@ -7,19 +7,8 @@ ansible_ssh_pass=fillme
 ## Hypervisor Repositories ##
 # Set repositories for installing hypervisors
 # Use either ovirt_rpm_repo or ovirt_dependency_repo, ovirt_rpm_repo
-#   ovirt_repo - URL of main repository file
-#   ovirt_dependency_repo - URL of dependency repository file
-#   ovirt_rpm_repo - URL of RPM package which contains repository files
-#
-#  Example:
-#    ovirt_repo=http://to.somewhere
-#    ovirt_dependency_repo=http://to.somewhere
-#  OR
-#    ovirt_rpm_repo=http://to.somewhere.rpm
-#
-ovirt_repo=fill me
-ovirt_dependency_repo=fill me
-#ovirt_rpm_repo=fill me
+#   for more information see:
+#     'ovirt-ansible/examples/inventory/group_vars/all.yml'
 
 [hypervisors]
 # Add ip or hostname of machines

--- a/roles/ovirt-common/tasks/main.yml
+++ b/roles/ovirt-common/tasks/main.yml
@@ -24,23 +24,30 @@
   tags:
     - skip_ansible_lint
 
-# get repository templates
-- name: copy repository file
+## OPTIONS
+# 1) get repository files
+- name: copy repository files
   get_url:
-    url: "{{ovirt_repo}}"
-    dest: "/etc/yum.repos.d/ansible_ovirt_main.repo"
+    url: "{{item.url}}"
+    dest: "/etc/yum.repos.d/{{item.name | default('')}}"
     force_basic_auth: yes
-  when: ovirt_repo is defined
+    force: "{{item.force | default('no')}}"
+  with_items: "{{ovirt_repo_file}}"
+  when: ovirt_repo_file is defined
 
-- name: copy dependency repository file
-  get_url:
-    url: "{{ovirt_dependency_repo}}"
-    dest: "/etc/yum.repos.d/ansible_ovirt_dependency.repo"
-    force_basic_auth: yes
-  when: ovirt_dependency_repo is defined
-
+# 2) install from rpm
 - name: install rpm repository package
   yum:
     name: "{{ovirt_rpm_repo}}"
     state: present
   when: ovirt_rpm_repo is defined
+
+# 3) create repository files
+- name: create repository files
+  yum_repository:
+    name: "{{item.name}}"
+    description: "{{item.name}}"
+    baseurl: "{{item.url}}"
+    enabled: "{{item.enabled | default('yes')}}"
+  with_items: "{{ovirt_repo}}"
+  when: ovirt_repo is defined


### PR DESCRIPTION
you can now get ovirt packages from 3 sources:
1) download repository file
2) create repository file
3) install rpm

add description of passing yaml variables to playbook
resolves: #63 #61