### PR TITLE
Remove ovirt_engine_answer_file_type

### DIFF
--- a/examples/inventory/install_engine.inv
+++ b/examples/inventory/install_engine.inv
@@ -25,14 +25,13 @@ ovirt_engine_dwh=True
 
 ## Engine setting ##
 # Main setting of engine installation
-# ovirt_engine_answer_file_type - choose type of installation
-#   '3.6_basic'  -   basic installation of engine 3.6 with default options
-#   '4.0_basic'  -   basic installation of engine 4.0 with default options
+# ovirt_engine_answer_file_path - local path to custom answerfile
+#   if not specified there is a default for every `ovirt_engine_version`
 # ovirt_engine_hostname - resolvable engine fqdn
 # ovirt_engine_organization - organisation (same as domain)
 # ovirt_engine_admin_password - admin@internal password
 #
-ovirt_engine_answer_file_type=4.0_basic
+ovirt_engine_answer_file_path=/local/path/to/ovirt.answer
 ovirt_engine_hostname=engine.host.fqdn.com
 ovirt_engine_organization=fqdn.com
 ovirt_engine_admin_password=123456

--- a/roles/ovirt-engine-install-packages/README.md
+++ b/roles/ovirt-engine-install-packages/README.md
@@ -10,12 +10,12 @@ Preinstalled clean environment with configured repositories
 
 Role Variables
 --------------
-    
+
     ovirt_engine_type: Type of product
         'ovirt-engine' - for installing oVirt product
-    ovirt_engine_version: Allowed version: [3.6, 4.x]
+    ovirt_engine_version: Allowed version: [3.6, 4.0, 4.1]
     ovirt_engine_dwh: Bool value for installing DWH (local - not need special answerfile)   
-    
+
 Dependencies
 ------------
 
@@ -27,16 +27,16 @@ Example Playbook
     hosts: engine
       remote_user: root
       vars:
-        # role-vars: ovirt-common 
+        # role-vars: ovirt-common
           # ovirt_dependency_repo: ''
           # ovirt_repo: ''
         ovirt_rpm_repo: 'http://resources.ovirt.org/pub/yum-repo/ovirt-release36.rpm'
-        
-        # role-vars: ovirt-engine-install-packages 
+
+        # role-vars: ovirt-engine-install-packages
         ovirt_engine_type: 'ovirt-engine'
         ovirt_engine_dwh: True
         ovirt_engine_version: '3.6'
-    
+
       roles:
         - { role: common }
         - { role: engine-install }

--- a/roles/ovirt-engine-setup/README.md
+++ b/roles/ovirt-engine-setup/README.md
@@ -3,6 +3,11 @@ Role Name
 
 engine-setup with answerfile
 
+By default engine-setup uses answer file specific for version of ovirt
+(set in ovirt_engine_version) or you can specify own answer file in
+ovirt_engine_answer_file_path.
+
+
 Requirements
 ------------
 
@@ -10,12 +15,12 @@ Preinstalled clean environment with configured repositories
 
 Role Variables
 --------------
-    
+
     ovirt_engine_type: Type of product
         'ovirt-engine' - for installing oVirt product
-    ovirt_engine_version: Allowed version: [3.6.x, 4.0.x]
+    ovirt_engine_version: Allowed version: [3.6, 4.0, 4.1]
     ovirt_engine_dwh: Bool value for installing local DWH
-    
+
     ovirt_engine_db_host: IP or hostname of PostgreSQL server for engine database (default: 'localhost')
     ovirt_engine_db_port: Server listening port (default 5432)
     ovirt_engine_db_name: DB name for ovirt-engine (default: 'engine')
@@ -26,8 +31,8 @@ Role Variables
     ovirt_engine_dwh_db_name: DB name for ovirt-engine-dwh (default: 'ovirt_engine_history')
     ovirt_engine_dwh_db_user: DB user which can access ovirt-engine-dwh DB (default: 'ovirt_engine_history')
     ovirt_engine_dwh_db_password: password for user of ovirt-engine DB
-    
-   
+
+
 Dependencies
 ------------
 
@@ -39,20 +44,19 @@ Example Playbook
     hosts: engine
       remote_user: root
       vars:
-        # role-vars: ovirt-common 
+        # role-vars: ovirt-common
           # ovirt_dependency_repo: ''
           # ovirt_repo: ''
         ovirt_rpm_repo: 'http://resources.ovirt.org/pub/yum-repo/ovirt-release36.rpm'
-        
-        # role-vars: ovirt-engine-install-packages 
+
+        # role-vars: ovirt-engine-install-packages
         ovirt_engine_type: 'ovirt-engine'
         ovirt_engine_dwh: True
         ovirt_engine_version: 3.6
-        
+
         # role-vars: ovirt-engine-setup
-        ovirt_engine_answer_file_type: '3.6_basic'
         ovirt_engine_hostname: 'engine.ovirt.org'
-        
+
         ovirt_engine_db_host: 'localhost'
         ovirt_engine_db_port: 5432
         ovirt_engine_db_name: 'engine'
@@ -63,7 +67,7 @@ Example Playbook
         ovirt_engine_dwh_db_name: 'ovirt_engine_history'
         ovirt_engine_dwh_db_user: 'ovirt_engine_history'
         ovirt_engine_dwh_db_password: '37xmBKECANQGm0z3SfylMp'
-        
+
       roles:
         - { role: common }
         - { role: engine-install }

--- a/roles/ovirt-engine-setup/defaults/main.yml
+++ b/roles/ovirt-engine-setup/defaults/main.yml
@@ -2,7 +2,7 @@
 ovirt_engine_dwh: True
 ovirt_engine_type: 'ovirt-engine'
 ovirt_engine_version: '4.0'
-ovirt_engine_answer_file_type: '4.0_basic'
+ovirt_engine_answer_file_path: ''
 ovirt_engine_admin_password: '123456'
 
 ovirt_engine_db_host: 'localhost'

--- a/roles/ovirt-engine-setup/tasks/main.yml
+++ b/roles/ovirt-engine-setup/tasks/main.yml
@@ -10,15 +10,25 @@
   until: ovirt_engine_status|success
   ignore_errors: True
 
-# copy answer file
-- name: copy answerfile
+# copy default answer file
+- name: copy default answerfile
   template:
-    # TODO generate this varialbe from ovirt_engine_version and ovirt_engine_dwh
-    src: answerfile_{{ovirt_engine_answer_file_type}}.txt.j2
+    src: answerfile_{{ovirt_engine_version}}_basic.txt.j2
     dest: /tmp/answerfile.txt
     mode: 0644
     owner: root
     group: root
+  when: not ovirt_engine_answer_file_path
+
+# copy custom answer file
+- name: copy custom answer file
+  copy:
+    src: "{{ovirt_engine_answer_file_path}}"
+    dest: /tmp/answerfile.txt
+    mode: 0644
+    owner: root
+    group: root
+  when: ovirt_engine_answer_file_path != ""
 
 - name: run engine-setup with answerfile
   shell: 'engine-setup --config-append=/tmp/answerfile.txt'

--- a/roles/ovirt-engine-setup/templates/answerfile_4.1_basic.txt.j2
+++ b/roles/ovirt-engine-setup/templates/answerfile_4.1_basic.txt.j2
@@ -1,0 +1,1 @@
+answerfile_4.0_basic.txt.j2


### PR DESCRIPTION
Every occurrence of ovirt_engine_answer_file_type
 variable is replaced by ovirt_engine_version.
It's possible to specify own answer file for
 engine-setup.

resolves: #29 