### PR TITLE
Role ovirt-common no longer update all packages

### DIFF
--- a/roles/ovirt-common/README.md
+++ b/roles/ovirt-common/README.md
@@ -2,7 +2,7 @@ Role Name
 =========
 
 Repository setup
-Role install necessary repositories and update system
+Role install necessary repositories
 
 Requirements
 ------------

--- a/roles/ovirt-common/tasks/main.yml
+++ b/roles/ovirt-common/tasks/main.yml
@@ -6,14 +6,6 @@
       must be specified. More information in the README"
   when: not ovirt_repo_file and not ovirt_rpm_repo and not ovirt_repo
 
-# ovirt-common tasks
-- name: upgrading all packages
-  yum:
-    name: '*'
-    state: "latest"
-  tags:
-    - skip_ansible_lint
-
 # install libselinux-python on machine - selinux policy
 - name: install libselinux-python for ansible
   yum:


### PR DESCRIPTION
Task that upgrade all packages in ovirt-common role was removed. That task was unnecessary.