### PR TITLE
remote-db: added option to customize access to remote db

### DIFF
--- a/roles/ovirt-engine-remote-db/README.md
+++ b/roles/ovirt-engine-remote-db/README.md
@@ -36,6 +36,12 @@ ovirt_engine_db_password: password for user of ovirt-engine DB
 ovirt_engine_dwh_db_name: DB name for ovirt-engine-dwh (default: 'ovirt_engine_history')
 ovirt_engine_dwh_db_user: DB user which can access ovirt-engine-dwh DB (default: 'ovirt_engine_history')
 ovirt_engine_dwh_db_password: password for user of ovirt-engine DB
+
+ovirt_engine_remote_db_access:  # configure access to engine remote DBs
+  -
+    type: host / local
+    address: 0.0.0.0/0   # mask for host, omitted for local
+    method: md5 / trust / ident / peer
 ```
 
 Dependencies
@@ -64,6 +70,14 @@ Example Playbook
     ovirt_engine_dwh_db_name: 'ovirt_engine_history'
     ovirt_engine_dwh_db_user: 'ovirt_engine_history'
     ovirt_engine_dwh_db_password: 123456
+    ovirt_engine_remote_db_access:
+      -
+        type: host
+        address: 0.0.0.0/0
+        method: md5
+      -
+        type: local
+        method: md5
   roles:
     - ovirt-engine-remote-db
 ```

--- a/roles/ovirt-engine-remote-db/defaults/main.yml
+++ b/roles/ovirt-engine-remote-db/defaults/main.yml
@@ -3,9 +3,17 @@ ovirt_engine_remote_db_port: 5432
 ovirt_engine_remote_db_listen_address: '*'
 ovirt_engine_db_name: 'engine'
 ovirt_engine_db_user: 'engine'
+ovirt_engine_db_password: 'AqbXg4dpkbcVRZwPbY8WOR'
 
 ovirt_engine_remote_db: False
 ovirt_engine_dwh_remote_db: False
 
 ovirt_engine_dwh_db_name: 'ovirt_engine_history'
 ovirt_engine_dwh_db_user: 'ovirt_engine_history'
+ovirt_engine_dwh_db_password: '37xmBKECANQGm0z3SfylMp'
+
+ovirt_engine_remote_db_access:
+  -
+    type: host
+    address: 0.0.0.0/0
+    method: md5

--- a/roles/ovirt-engine-remote-db/tasks/main.yml
+++ b/roles/ovirt-engine-remote-db/tasks/main.yml
@@ -2,26 +2,21 @@
 # main file for remote DB task
 # based on https://fedoraproject.org/wiki/PostgreSQL
 
+# install libselinux-python on machine - selinux policy
+- name: install SELinux requirements to run ansible modules managing SELinux.
+  yum:
+    name: "{{ item }}"
+    state: "present"
+  with_items:
+    - libselinux-python
+    - policycoreutils-python
+
 - name: check PostgreSQL service
   service:
     name: postgresql
     state: started
   register: postgresql_status
   ignore_errors: True
-
-# install libselinux-python on machine - selinux policy
-- name: install libselinux-python for ansible
-  yum:
-    name: libselinux-python
-    state: "present"
-  when: postgresql_status|failed
-
-# for semanage utility
-- name: install policycoreutils-python for changing selinux port
-  yum:
-    name: policycoreutils-python
-    state: "present"
-  when: postgresql_status|failed
 
 - name: yum install PostgreSQL
   yum:
@@ -30,10 +25,20 @@
     update_cache: yes
   when: postgresql_status|failed
 
+- name: enable sudo without tty
+  lineinfile:
+    path: /etc/sudoers
+    state: present
+    regexp: '^Defaults *requiretty$'
+    line: 'Defaults    !requiretty'
+  when: postgresql_status|failed
+
 - name: run PostgreSQL initdb
   become_user: postgres
   become: yes
   shell: '/usr/bin/initdb -D /var/lib/pgsql/data'
+  args:
+    creates: "/var/lib/pgsql/data/postgresql.conf"
   when: postgresql_status|failed
   tags:
     - skip_ansible_lint
@@ -45,35 +50,44 @@
     enabled: yes
 
 # allow access engine database access from outside
-- name: update pg_hba.conf -> host ovirt_engine_db_name ovirt_engine_db_user 0.0.0.0/0 md5
+- name: "update pg_hba.conf to allow connection for ovirt_engine_remote_db"
   lineinfile:
     dest: '/var/lib/pgsql/data/pg_hba.conf'
+    line: >
+      {{ item.type }} {{ ovirt_engine_db_name }} {{ ovirt_engine_db_user }}
+      {{ item.address | default(' ') }} {{ item.method }}
     insertafter: EOF
-    line: "host {{ovirt_engine_db_name}} {{ovirt_engine_db_user}} 0.0.0.0/0 md5"
+  with_items: "{{ ovirt_engine_remote_db_access | list }}"
   when: ovirt_engine_remote_db == True
 
-# allow access dwh database access from outside
-- name: update pg_hba.conf -> host ovirt_engine_db_dwh_name ovirt_engine_db_dwh_user 0.0.0.0/0 md5
+# allow access engine dwh database access from outside
+- name: "update pg_hba.conf to allow connection for ovirt_engine_dwh_remote_db"
   lineinfile:
     dest: '/var/lib/pgsql/data/pg_hba.conf'
+    line: >
+      {{ item.type }} {{ ovirt_engine_dwh_db_name }}
+      {{ ovirt_engine_dwh_db_user }} {{ item.address | default(' ') }}
+      {{ item.method }}
     insertafter: EOF
-    line: "host {{ovirt_engine_dwh_db_name}} {{ovirt_engine_dwh_db_user}} 0.0.0.0/0 md5"
+  with_items: "{{ ovirt_engine_remote_db_access | list }}"
   when: ovirt_engine_dwh_remote_db == True
 
 # listen on specific address
 - name: update postgresql.conf -> listen_addresses='*'
   lineinfile:
     dest: '/var/lib/pgsql/data/postgresql.conf'
-    insertafter: EOF
+    regexp: "^listen_addresses *=.*$"
     line: "listen_addresses='{{ovirt_engine_remote_db_listen_address}}'"
+    insertafter: EOF
   when: postgresql_status|failed
 
 # listen on specific port
 - name: update postgresql.conf -> port number
   lineinfile:
     dest: '/var/lib/pgsql/data/postgresql.conf'
+    regexp: "^port *=.*$"
+    line: "port={{ ovirt_engine_remote_db_port }}"
     insertafter: EOF
-    line: "port={{ovirt_engine_remote_db_port}}"
   when: postgresql_status|failed and ovirt_engine_remote_db_port != 5432
 
 # postgresql.conf: (el7)
@@ -85,8 +99,8 @@
   lineinfile:
     dest: '/usr/lib/systemd/system/postgresql.service'
     backrefs: yes
-    regexp: "Environment=PGPORT=5432"
-    line: "Environment=PGPORT={{ovirt_engine_remote_db_port}}"
+    regexp: "^Environment=PGPORT *=.*$"
+    line: "Environment=PGPORT={{ ovirt_engine_remote_db_port }}"
   register: port_update
   when: postgresql_status|failed and ovirt_engine_remote_db_port != 5432
   ignore_errors: True
@@ -103,18 +117,20 @@
   lineinfile:
     dest: '/etc/init.d/postgresql'
     backrefs: yes
-    regexp: "PGPORT=5432"
-    line: "PGPORT={{ovirt_engine_remote_db_port}}"
+    regexp: "^PGPORT *=.*$"
+    line: "PGPORT={{ ovirt_engine_remote_db_port }}"
   when: postgresql_status|failed and ovirt_engine_remote_db_port != 5432 and port_update|failed
   ignore_errors: True
 
 # allow selinux for postgresql non-standard port
 - name: allow selinux for non-standard port
-  shell: 'semanage port -a -t postgresql_port_t -p tcp {{ovirt_engine_remote_db_port}}'
+  seport:
+    ports: "{{ ovirt_engine_remote_db_port }}"
+    proto: "tcp"
+    setype: "postgresql_port_t"
+    state: present
   when: postgresql_status|failed and ovirt_engine_remote_db_port != 5432
   ignore_errors: True
-  tags:
-    - skip_ansible_lint
 
 # first check of PostgreSQL - if fail, setup
 - name: PostgreSQL reload configuration

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,7 @@
 localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env python"
+
+[engine]
+engine_centos7 image="chrismeyers/centos7"
+
+[remote-db]
+remote_db_centos7 image="chrismeyers/centos7"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,26 +2,43 @@
 - name: Bring up docker containers
   hosts: localhost
   gather_facts: false
-  vars:
-    inventory:
-      - name: engine_centos7
-        image: "chrismeyers/centos7"
   roles:
     - role: provision_docker
-      provision_docker_inventory: "{{ inventory }}"
+      provision_docker_inventory_group: "{{ groups['remote-db'] }}"
+    - role: provision_docker
+      provision_docker_inventory_group: "{{ groups['engine'] }}"
+
+
+- name: Deploy node for ovirt-engine remote DB
+  hosts: remote-db
+  vars:
+    ovirt_engine_remote_db: True
+    ovirt_engine_dwh_remote_db: True
+    ovirt_engine_remote_db_access:
+      -
+        type: host
+        address: 0.0.0.0/0
+        method: md5
+      -
+        type: local
+        method: trust
+  roles:
+    - role: ovirt-engine-remote-db
 
 
 - name: Run ovirt-ansible roles on containerized environments
-  hosts: docker_containers
+  hosts: engine
   vars:
     ovirt_engine_type: "ovirt-engine"
     ovirt_engine_version: "4.1"
     ovirt_rpm_repo: "http://plain.resources.ovirt.org/pub/yum-repo/ovirt-release41.rpm"
-    ovirt_engine_dwh: True
-    ovirt_engine_configure_iso_domain: True
     ovirt_engine_hostname: "localhost"
     ovirt_engine_organization: "example.com"
     ovirt_engine_admin_password: "123456"
+    ovirt_engine_db_host: "{{ hostvars['remote_db_centos7']['ansible_default_ipv4']['address'] }}"
+    ovirt_engine_dwh: True
+    ovirt_engine_dwh_db_host: "{{ hostvars['remote_db_centos7']['ansible_default_ipv4']['address'] }}"
+    ovirt_engine_configure_iso_domain: True
     ovirt_engine_firewall_manager: null
     ovirt_engine_config:
       -
@@ -41,12 +58,15 @@
     - role: ovirt-iso-uploader-conf
 #    - role: ovirt-collect-logs  # Issue #102
 
+
 - name: Run ovirt-engine-cleanup on containerized environments
-  hosts: docker_containers
+  hosts: engine
   vars:
     ovirt_engine_type: "ovirt-engine"
     ovirt_engine_version: "4.1"
-    ovirt_engine_dwh: True
     ovirt_engine_hostname: "localhost"
+    ovirt_engine_db_host: "{{ hostvars['remote_db_centos7']['ansible_default_ipv4']['address'] }}"
+    ovirt_engine_dwh: True
+    ovirt_engine_dwh_db_host: "{{ hostvars['remote_db_centos7']['ansible_default_ipv4']['address'] }}"
   roles:
     - role: ovirt-engine-cleanup  # This role must be last

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ commands =
         {[testenv:yamllint]commands}
         {[testenv:ansible-syntax]commands}
         {[testenv:ansible-lint]commands}
-	{[testenv:flake8]commands}
+        {[testenv:flake8]commands}


### PR DESCRIPTION
1) added option to customize access to remote db

some time we need to grant access from local,
and also restrict subnet from where the connection
can be established from.

2) update test that it use remote deployment of db

it create separate container and deploy remote db there
for engine and dwh.