### PR TITLE
Fix test for oVirt master

### DIFF
--- a/tests/containers-deploy.yml
+++ b/tests/containers-deploy.yml
@@ -7,3 +7,11 @@
       provision_docker_inventory_group: "{{ groups['remote-db'] }}"
     - role: provision_docker
       provision_docker_inventory_group: "{{ groups['engine'] }}"
+
+- name: "Update python because of ovirt-imageio-proxy"
+  hosts: engine
+  tasks:
+    - name: Update python
+      yum:
+        name: python-libs
+        state: latest


### PR DESCRIPTION
the ovirt-imageio-proxy requires latest python-libs because it
uses new features from ssl module.