### PR TITLE
ovirt-guest-agent: remove variable from handler name

### DIFF
--- a/roles/ovirt-guest-agent/README.md
+++ b/roles/ovirt-guest-agent/README.md
@@ -21,7 +21,7 @@ Role Variables
 
 ```yaml
 ---
-ovirt_guest_agent_pkg_prefix: "ovirt|rhevm|qemu"
+ovirt_guest_agent_pkg_prefix: "ovirt|rhevm"
 ```
 
 Default value if variable not given is ```ovirt```.

--- a/roles/ovirt-guest-agent/handlers/main.yaml
+++ b/roles/ovirt-guest-agent/handlers/main.yaml
@@ -1,6 +1,7 @@
 ---
-- name: enable and start {{ ovirt_guest_agent_pkg_prefix }}-guest-agent
+- name: enable and start guest-agent service
   service:
-    name: "{{ ovirt_guest_agent_pkg_prefix }}-guest-agent"
+    # Name of service is same for both packages (ovirt/rhevm)
+    name: "ovirt-guest-agent"
     state: started
     enabled: yes

--- a/roles/ovirt-guest-agent/tasks/main.yml
+++ b/roles/ovirt-guest-agent/tasks/main.yml
@@ -4,6 +4,6 @@
     state: latest
   with_items:
     - "{{ ovirt_guest_agent_pkg_prefix }}-guest-agent"
-  notify: enable and start {{ ovirt_guest_agent_pkg_prefix }}-guest-agent
+  notify: enable and start guest-agent service
   tags:
     - skip_ansible_lint


### PR DESCRIPTION
It fails for different value from defaults

Fix #134 