### PR TITLE
tests:test-updrade40to41: added engine-rename role

### DIFF
--- a/tests/test-upgrade-4.0-to-4.1.yml
+++ b/tests/test-upgrade-4.0-to-4.1.yml
@@ -9,6 +9,7 @@
   vars:
     ovirt_engine_version: "4.1"
     ovirt_rpm_repo: "http://plain.resources.ovirt.org/pub/yum-repo/ovirt-release41.rpm"
+- include: engine-rename.yml
 - include: engine-cleanup.yml
   vars:
     ovirt_engine_version: "4.1"


### PR DESCRIPTION
Missed out on adding the engine rename test to `tests/test-upgrade-4.0-to-4.1.yml`