### PR TITLE
Fix issue: Postgres95 vars not loaded for RH env

### DIFF
--- a/roles/ovirt-engine-remote-db/tasks/main.yml
+++ b/roles/ovirt-engine-remote-db/tasks/main.yml
@@ -5,11 +5,11 @@
 - name: Include postgres params
   include_vars: default.yml
 
-- name: Override postgres params for CentOs or Red Hat when ovirt >= 4.2
+- name: Override postgres params for CentOs or RedHat when ovirt >= 4.2
   include_vars: postgres95.yml
   when:
     - ovirt_engine_version >= '4.2'
-    - ansible_distribution in ('CentOS', 'Red Hat')
+    - ansible_distribution in ('CentOS', 'RedHat')
 
 # install libselinux-python on machine - selinux policy
 - name: install SELinux requirements to run ansible modules managing SELinux.
@@ -52,7 +52,7 @@
   when:
     - postgresql_status|failed
     - ovirt_engine_version >= '4.2'
-    - ansible_distribution in ('CentOS', 'Red Hat')
+    - ansible_distribution in ('CentOS', 'RedHat')
   tags:
     - skip_ansible_lint
 


### PR DESCRIPTION
The condition

 `ansible_distribution in ('CentOS', 'Red Hat')`

will evaluate to false as ansible_distribution returns 'RedHat' on RH systems and not "Red Hat".  This issue prevents the right variables from being loaded in addition to mistakenly skipping certain tasks. To resolve this 'Red Hat' was replaced with 'RedHat'

Here we can see the debug statement showing the variables for ansible_distrubtion check for 'Red Hat' and 'Redhat'


```
- debug:
    msg: "ansible_distribution in ('CentOS', 'RedHat') => {{ansible_distribution in ('CentOS', 'RedHat')}} and ansible_distribution => {{ansible_distribution}} "

- debug:
    msg: "ansible_distribution in ('CentOS', 'Red Hat') => {{ansible_distribution in ('CentOS', 'Red Hat')}} and ansible_distribution => {{ansible_distribution}} "

```



TASK [ovirt-engine-remote-db : debug] ********************************************************************************************************************************************************
task path: /tmp/ovirt-ansible/roles/ovirt-engine-remote-db/tasks/main.yml:8
ok: [redacted_host_name] => {
    "msg": "ansible_distribution in ('CentOS', 'RedHat') => True and ansible_distribution => RedHat "
}

TASK [ovirt-engine-remote-db : debug] ********************************************************************************************************************************************************
task path: /tmp/ovirt-ansible/roles/ovirt-engine-remote-db/tasks/main.yml:11
ok: [redacted_host_name] => {
    "msg": "ansible_distribution in ('CentOS', 'Red Hat') => False and ansible_distribution => RedHat "




