### PR TITLE
Add journalctl log on logs collection

### DIFF
--- a/roles/ovirt-collect-logs/vars/main.yml
+++ b/roles/ovirt-collect-logs/vars/main.yml
@@ -14,3 +14,4 @@ ovirt_collect_logs_shell_commands:
   lsmod: "lsmod"
   lspci: "lspci"
   memory_usage: "ps -e -orss=,args= | sort  -b -k1,1n | tac"
+  journalctl: "journalctl -xb"


### PR DESCRIPTION
This patch is needed to help track service level errors on systemd journal log.