### PR TITLE
Handle case for empty /var/log/messages and add journalctl logs

### DIFF
--- a/roles/ovirt-collect-logs/tasks/main.yml
+++ b/roles/ovirt-collect-logs/tasks/main.yml
@@ -34,21 +34,18 @@
   tags:
     - skip_ansible_lint # check for shell module is not working correctly in Lint
 
-- name: Check if /var/log/messages exists else we have to use journalctl
+- name: Check if log /var/log/messages exists
   stat: path=/var/log/messages
-  register: message_file
+  register: message_file_exits
 
-- name: Copy journalctl output if /var/log/messages is missing
-  shell: journalctl > "/var/log/messages"
-  when: not message_file.stat.exists
-
-- name: Link common logs
+- name: Collect log /var/log/messages
   file:
     src: "{{ item.src }}"
     dest: "{{ ovirt_collect_logs_tmp_dir }}/{{ item.dest }}"
     state: link
   with_items:
     - { src: "/var/log/messages", dest: "messages" }
+  when: message_file_exits
 
 # Collect system specific stuff
 

--- a/roles/ovirt-collect-logs/vars/main.yml
+++ b/roles/ovirt-collect-logs/vars/main.yml
@@ -14,3 +14,4 @@ ovirt_collect_logs_shell_commands:
   lsmod: "lsmod"
   lspci: "lspci"
   memory_usage: "ps -e -orss=,args= | sort  -b -k1,1n | tac"
+  journalctl: "journalctl -xb"


### PR DESCRIPTION
Handle case where log: /var/log/messages is empty, and add additional logging with 
journalctl to cover cases where /var/log/messages does not contain enough information (https://access.redhat.com/solutions/2140041).