### PR TITLE
Fix CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,8 @@ env:
   global:
     - ANSIBLE_HOST_KEY_CHECKING="False"
   matrix:
-#    - TEST_NAME=3.6
-#    - TEST_NAME=4.0
-    - TEST_NAME=4.1
+    # We don't support older versions here. Also upstream doesn't support 4.1
+    # when 4.2 is out. https://bugzilla.redhat.com/show_bug.cgi?id=1583222
     - TEST_NAME=4.2
 
 # Install python-pip

--- a/tests/test-4.2.yml
+++ b/tests/test-4.2.yml
@@ -8,6 +8,8 @@
   vars:
     ovirt_engine_version: "4.2"
     ovirt_rpm_repo: "http://plain.resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm"
+    # OVN is failing under docker, problem is to start openvswitch service.
+    ovirt_engine_setup_provider_ovn_configure: false
 - include: engine-rename.yml
   vars:
     ovirt_engine_rename_new_fqdn: "test.ovirt.org"


### PR DESCRIPTION
4.1 - disabled testing cause also upstream doesn't support it.
4.2 - disable openvswitch cause it's failing on dockered env to start
      openvswitch service
Fixes: #171 