### PR TITLE
Make the success testing 2.9 compatible

### DIFF
--- a/roles/ovirt-collect-logs/tasks/main.yml
+++ b/roles/ovirt-collect-logs/tasks/main.yml
@@ -6,6 +6,10 @@
   yum:
     name: ['gzip', 'tar']
     state: "present"
+  register: yum_result
+  until: yum_result is success
+  retries: 3
+  delay: 10
 
 # Prepare place to store data
 

--- a/roles/ovirt-engine-backup/tasks/main.yml
+++ b/roles/ovirt-engine-backup/tasks/main.yml
@@ -11,11 +11,11 @@
   fetch:
     src: "{{ovirt_backup_archive}}"
     dest: "{{ovirt_backup_archive}}"
-  when: ovirt_backup_status|succeeded
+  when: ovirt_backup_status is succeeded
 
 # download log file to ansible-client node
 - name: download log file
   fetch:
     src: "{{ovirt_log_file}}"
     dest: "{{ovirt_log_file}}"
-  when: ovirt_backup_status|failed
+  when: ovirt_backup_status is failed

--- a/roles/ovirt-engine-config/handlers/main.yml
+++ b/roles/ovirt-engine-config/handlers/main.yml
@@ -12,4 +12,4 @@
   register: health_page
   retries: 12
   delay: 10
-  until: health_page|success
+  until: health_page is success

--- a/roles/ovirt-engine-remote-db/tasks/main.yml
+++ b/roles/ovirt-engine-remote-db/tasks/main.yml
@@ -152,7 +152,7 @@
 # daemon reload - service file was changed
 - name: systemctl daemon-reload (el7)
   shell: 'systemctl daemon-reload'
-  when: postgresql_status|failed and ovirt_engine_remote_db_port != 5432 and port_update|success
+  when: postgresql_status|failed and ovirt_engine_remote_db_port != 5432 and port_update is success
   tags:
     - skip_ansible_lint
 

--- a/roles/ovirt-engine-remote-db/tasks/main.yml
+++ b/roles/ovirt-engine-remote-db/tasks/main.yml
@@ -19,11 +19,19 @@
   with_items:
     - libselinux-python
     - policycoreutils-python
+  register: yum_result
+  until: yum_result is success
+  retries: 3
+  delay: 10
 
 - name: install psycopg2 requirements to run ansible modules managing postgres.
   yum:
     name: "python-psycopg2"
     state: "present"
+  register: yum_result
+  until: yum_result is success
+  retries: 3
+  delay: 10
 
 - name: Install PostgreSQL uuid-ossp extension
   yum:
@@ -32,6 +40,10 @@
   when:
     - ovirt_engine_version >= '4.2'
     - ansible_distribution in ('CentOS', 'RedHat')
+  register: yum_result
+  until: yum_result is success
+  retries: 3
+  delay: 10
 
 - name: check PostgreSQL service
   service:
@@ -46,11 +58,19 @@
     state: installed
     update_cache: yes
   when: postgresql_status|failed
+  register: yum_result
+  until: yum_result is success
+  retries: 3
+  delay: 10
 
 - name: install sudo package
   yum:
     name: sudo
     state: present
+  register: yum_result
+  until: yum_result is success
+  retries: 3
+  delay: 10
 
 - name: enable sudo without tty
   lineinfile:

--- a/roles/ovirt-engine-remote-db/tasks/main.yml
+++ b/roles/ovirt-engine-remote-db/tasks/main.yml
@@ -78,7 +78,7 @@
     state: present
     regexp: '^Defaults *requiretty$'
     line: 'Defaults    !requiretty'
-  when: postgresql_status is is failed
+  when: postgresql_status is failed
 
 - name: scl enable
   shell: 'scl enable rh-postgresql95 bash'

--- a/roles/ovirt-engine-remote-db/tasks/main.yml
+++ b/roles/ovirt-engine-remote-db/tasks/main.yml
@@ -57,7 +57,7 @@
     name: "{{ postgres_server }}"
     state: installed
     update_cache: yes
-  when: postgresql_status|failed
+  when: postgresql_status is failed
   register: yum_result
   until: yum_result is success
   retries: 3
@@ -78,12 +78,12 @@
     state: present
     regexp: '^Defaults *requiretty$'
     line: 'Defaults    !requiretty'
-  when: postgresql_status|failed
+  when: postgresql_status is is failed
 
 - name: scl enable
   shell: 'scl enable rh-postgresql95 bash'
   when:
-    - postgresql_status|failed
+    - postgresql_status is failed
     - ovirt_engine_version >= '4.2'
     - ansible_distribution in ('CentOS', 'RedHat')
   tags:
@@ -143,7 +143,7 @@
     regexp: "^listen_addresses *=.*$"
     line: "listen_addresses='{{ovirt_engine_remote_db_listen_address}}'"
     insertafter: EOF
-  when: postgresql_status|failed
+  when: postgresql_status is failed
 
 # listen on specific port
 - name: update postgresql.conf -> port number
@@ -152,7 +152,7 @@
     regexp: "^port *=.*$"
     line: "port={{ ovirt_engine_remote_db_port }}"
     insertafter: EOF
-  when: postgresql_status|failed and ovirt_engine_remote_db_port != 5432
+  when: postgresql_status is failed and ovirt_engine_remote_db_port != 5432
 
 # postgresql.conf: (el7)
 # Note: In RHEL/Fedora installations, you can't set the port number here;
@@ -166,13 +166,13 @@
     regexp: "^Environment=PGPORT *=.*$"
     line: "Environment=PGPORT={{ ovirt_engine_remote_db_port }}"
   register: port_update
-  when: postgresql_status|failed and ovirt_engine_remote_db_port != 5432
+  when: postgresql_status is failed and ovirt_engine_remote_db_port != 5432
   ignore_errors: True
 
 # daemon reload - service file was changed
 - name: systemctl daemon-reload (el7)
   shell: 'systemctl daemon-reload'
-  when: postgresql_status|failed and ovirt_engine_remote_db_port != 5432 and port_update is success
+  when: postgresql_status is failed and ovirt_engine_remote_db_port != 5432 and port_update is success
   tags:
     - skip_ansible_lint
 
@@ -183,7 +183,7 @@
     backrefs: yes
     regexp: "^PGPORT *=.*$"
     line: "PGPORT={{ ovirt_engine_remote_db_port }}"
-  when: postgresql_status|failed and ovirt_engine_remote_db_port != 5432 and port_update|failed
+  when: postgresql_status is failed and ovirt_engine_remote_db_port != 5432 and port_update is failed
   ignore_errors: True
 
 # Required for vacuum feature
@@ -203,7 +203,7 @@
     proto: "tcp"
     setype: "postgresql_port_t"
     state: present
-  when: postgresql_status|failed and ovirt_engine_remote_db_port != 5432
+  when: postgresql_status is failed and ovirt_engine_remote_db_port != 5432
   ignore_errors: True
 
 # first check of PostgreSQL - if fail, setup
@@ -217,22 +217,22 @@
     name: iptables
     state: started
   register: iptables_status
-  when: postgresql_status|failed
+  when: postgresql_status is failed
   ignore_errors: True
 
 - name: open port for PostgreSQL in iptables
   shell: "iptables -I INPUT -s {{ item.address }} -p tcp -m state --state NEW -m tcp --dport {{ovirt_engine_remote_db_port}} -j ACCEPT"
   with_items: "{{ ovirt_engine_remote_db_access | list }}"
   when:
-    - postgresql_status|failed
-    - not iptables_status|failed
+    - postgresql_status is failed
+    - not iptables_status is failed
     - item.address is defined
   tags:
     - skip_ansible_lint
 
 - name: save iptables rules
   shell: "/sbin/iptables-save"
-  when: postgresql_status|failed and not iptables_status|failed
+  when: postgresql_status is failed and not iptables_status is failed
   tags:
     - skip_ansible_lint
 
@@ -241,7 +241,7 @@
     name: firewalld
     state: started
   register: firewalld_status
-  when: postgresql_status|failed
+  when: postgresql_status is failed
   ignore_errors: True
 
 - name: open port for PostgreSQL in firewalld
@@ -252,13 +252,13 @@
     state: enabled
   with_items: "{{ ovirt_engine_remote_db_access | list }}"
   when:
-    - postgresql_status|failed
-    - not firewalld_status|failed
+    - postgresql_status is failed
+    - not firewalld_status is failed
     - item.address is defined
 
 - name: reload firewalld
   shell: "firewall-cmd --reload"
-  when: postgresql_status|failed and not firewalld_status|failed
+  when: postgresql_status is failed and not firewalld_status is failed
   tags:
     - skip_ansible_lint
 

--- a/roles/ovirt-engine-remote-dwh/install-postgresql/tasks/main.yml
+++ b/roles/ovirt-engine-remote-dwh/install-postgresql/tasks/main.yml
@@ -11,7 +11,7 @@
     name: postgresql-server
     state: installed
     update_cache: yes
-  when: postgresql_status|failed
+  when: postgresql_status is failed
   register: yum_result
   until: yum_result is success
   retries: 3
@@ -24,13 +24,13 @@
 
 - name: Initialize the postgresql db
   command: su -l postgres -c "/usr/bin/initdb --locale=en_US.UTF8 --auth='ident' --pgdata=/var/lib/pgsql/data/"
-  when: postgresql_status|failed
+  when: postgresql_status is failed
 
 - name: Start postgresql.service
   systemd:
     state: started
     name: postgresql
-  when: postgresql_status|failed
+  when: postgresql_status is failed
 
 - name: creating directory for sql scripts in /tmp/ansible-sql
   file:

--- a/roles/ovirt-engine-remote-dwh/install-postgresql/tasks/main.yml
+++ b/roles/ovirt-engine-remote-dwh/install-postgresql/tasks/main.yml
@@ -7,13 +7,17 @@
   ignore_errors: True
 
 - name: install postgresql
-  yum: 
+  yum:
     name: postgresql-server
     state: installed
     update_cache: yes
   when: postgresql_status|failed
+  register: yum_result
+  until: yum_result is success
+  retries: 3
+  delay: 10
 
-- name: Check if the db is initialized 
+- name: Check if the db is initialized
   stat:
     path: /var/lib/pgsql/data
   register: db_initialised
@@ -50,7 +54,7 @@
   command: psql -p {{ ovirt_engine_dwh_db_port }} -a -f /tmp/ansible-sql/'{{ item }}'
   with_items:
     - "ovirt-engine-dwh-db-user-create.sql"
-    - "ovirt-engine-dwh-db-create.sql"      
+    - "ovirt-engine-dwh-db-create.sql"
 
 - name: Adding engine and dwhservice vm IP's in the dwhdb conf to be acessed remotely
   lineinfile:
@@ -72,12 +76,12 @@
     - systemctl start firewalld
     - firewall-cmd --zone=public --add-port=5432/tcp --permanent
     - firewall-cmd --reload
-  
+
 - name: Restart postgresql for the loading the newer configs
   systemd:
     state: restarted
     name: postgresql
-    
+
 - name: check PostgreSQL service
   service:
     name: postgresql

--- a/roles/ovirt-engine-remote-dwh/tasks/main.yml
+++ b/roles/ovirt-engine-remote-dwh/tasks/main.yml
@@ -7,7 +7,7 @@
   register: ovirt_engine_status
   retries: 2
   delay: 5
-  until: ovirt_engine_status|success
+  until: ovirt_engine_status is success
   ignore_errors: True
 
 # copy dwh on dwh answer file
@@ -52,7 +52,7 @@
   register: ovirt_engine_status
   retries: 12
   delay: 5
-  until: ovirt_engine_status|success
+  until: ovirt_engine_status is success
   ignore_errors: True
 
 - name: Restart `ovirt-engine-dwhd` service

--- a/roles/ovirt-engine-rename/tasks/main.yml
+++ b/roles/ovirt-engine-rename/tasks/main.yml
@@ -68,4 +68,4 @@
   register: health_page
   retries: 12
   delay: 10
-  until: health_page|success
+  until: health_page is success

--- a/roles/ovirt-guest-agent/tasks/main.yml
+++ b/roles/ovirt-guest-agent/tasks/main.yml
@@ -4,6 +4,10 @@
     state: latest
   with_items:
     - "{{ ovirt_guest_agent_pkg_prefix }}-guest-agent"
+  register: yum_result
+  until: yum_result is success
+  retries: 3
+  delay: 10
   notify: enable and start guest-agent service
   tags:
     - skip_ansible_lint


### PR DESCRIPTION
Change the '|success' test to 'is success'. Using the filter way (the pipe) was removed from ansible 2.9.