### PR TITLE
RHEVM-5428 adding additional logs to be fetched from engine and hosts

### DIFF
--- a/roles/ovirt-collect-logs/tasks/engine.yml
+++ b/roles/ovirt-collect-logs/tasks/engine.yml
@@ -46,6 +46,13 @@
     -
       src: "/var/log/ovirt-imageio"
       dest: "ovirt-imageio-logs"
+    -
+      src: "/var/log/ovirt-guest-agent/ovirt-guest-agent.log"
+      dest: "ovirt-guest-agent.log"
+    -
+      src: "/var/log/openvswitch/ovsdb-server-nb.log"
+      dest: "ovsdb-server-nb.log"
+
   ignore_errors: true
 
 - name: Link ovirt-requests logs

--- a/roles/ovirt-collect-logs/tasks/hypervisor.yml
+++ b/roles/ovirt-collect-logs/tasks/hypervisor.yml
@@ -50,6 +50,10 @@
     -
       src: "/var/log/sanlock.log"
       dest: "sanlock.log"
+    -
+      src: "/var/log/openvswitch/ovsdb-server.log"
+      dest: "ovsdb-server.log"
+
   ignore_errors: true
 
 - name: Dump mount


### PR DESCRIPTION
Just added the following (others were already there):

Engine:
/var/log/ovirt-guest-agent/ovirt-guest-agent.log
/var/log/openvswitch/ovsdb-server-nb.log

Hosts:
/var/log/openvswitch/ovsdb-server.log