### PR TITLE
add condition for prefix of guest agent package

### DIFF
--- a/roles/ovirt-guest-agent/defaults/main.yml
+++ b/roles/ovirt-guest-agent/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-ovirt_guest_agent_pkg_prefix: ovirt
+ovirt_guest_agent_pkg_prefix: "{{ 'ovirt' if ansible_distribution_major_version < '8' else 'qemu' }}"

--- a/roles/ovirt-guest-agent/handlers/main.yaml
+++ b/roles/ovirt-guest-agent/handlers/main.yaml
@@ -1,8 +1,6 @@
 ---
 - name: enable and start guest-agent service
   service:
-    # Name of service is same for both packages (ovirt/rhevm) but for RHEL 8
-    # it's qemu
-    name: "{{ 'qemu' if ovirt_guest_agent_pkg_prefix == 'qemu' else 'ovirt' }}-guest-agent"
+    name: "{{ ovirt_guest_agent_pkg_prefix }}-guest-agent"
     state: started
     enabled: yes

--- a/roles/ovirt-guest-agent/tasks/main.yml
+++ b/roles/ovirt-guest-agent/tasks/main.yml
@@ -1,9 +1,7 @@
 - name: Install latest {{ ovirt_guest_agent_pkg_prefix }}-guest-agent
   yum:
-    name: "{{ item }}"
+    name: "{{ ovirt_guest_agent_pkg_prefix }}-guest-agent"
     state: latest
-  with_items:
-    - "{{ ovirt_guest_agent_pkg_prefix }}-guest-agent"
   register: yum_result
   until: yum_result is success
   retries: 3


### PR DESCRIPTION
the ovirt_guest_agent_pkg_prefix depends on the rhel major version.
when rhel major version < 8 it should be:
ovirt-guest-agent
else
qemu-guest-agent