### PR TITLE
Infra: Fix issue when fetched messages log is empty

### DIFF
--- a/roles/ovirt-collect-logs/tasks/main.yml
+++ b/roles/ovirt-collect-logs/tasks/main.yml
@@ -41,7 +41,7 @@
 
 - name: Copy journalctl output if /var/log/messages is missing
   shell: journalctl > "/var/log/messages"
-  when: not message_file.stat.exists
+  when: not message_file.stat.exists or message_file.stat.size == 0
 
 - name: Link common logs
   file:


### PR DESCRIPTION
RHEVM-5930
This is caused by the fact that sometimes (usually on engine) the
messages log remains empty.
I WA this by fetching 'journalctl' log in case the messages does not
exist, or is empty.