### PR TITLE
Add tasks to collect OVN/OVS logs

### DIFF
--- a/roles/ovirt-collect-logs/tasks/engine.yml
+++ b/roles/ovirt-collect-logs/tasks/engine.yml
@@ -55,6 +55,21 @@
 
   ignore_errors: true
 
+- name: Link ovn and openvswitch logs
+  file:
+    src: "{{ item.src }}"
+    dest: "{{ ovirt_collect_logs_tmp_dir }}/{{ item.dest }}"
+    state: link
+  with_items:
+    -
+      src: "/var/log/ovn"
+      dest: "ovn-logs"
+    -
+      src: "/var/log/openvswitch"
+      dest: "ovs-logs"
+
+  ignore_errors: true
+
 - name: Link ovirt-requests logs
   file:
     src: "{{ item }}"

--- a/roles/ovirt-collect-logs/tasks/engine.yml
+++ b/roles/ovirt-collect-logs/tasks/engine.yml
@@ -57,7 +57,7 @@
       dest: "ovn-logs"
 
     - src: "/var/log/openvswitch"
-      dest: "ovs-logs"
+      dest: "openvswitch-logs"
 
   ignore_errors: true
 

--- a/roles/ovirt-collect-logs/tasks/engine.yml
+++ b/roles/ovirt-collect-logs/tasks/engine.yml
@@ -53,20 +53,10 @@
       src: "/var/log/openvswitch/ovsdb-server-nb.log"
       dest: "ovsdb-server-nb.log"
 
-  ignore_errors: true
-
-- name: Link ovn and openvswitch logs
-  file:
-    src: "{{ item.src }}"
-    dest: "{{ ovirt_collect_logs_tmp_dir }}/{{ item.dest }}"
-    state: link
-  with_items:
-    -
-      src: "/var/log/ovn"
+    - src: "/var/log/ovn"
       dest: "ovn-logs"
-    -
-      src: "/var/log/openvswitch"
-      dest: "ovs-logs"
+        - src: "/var/log/openvswitch"
+          dest: "ovs-logs"
 
   ignore_errors: true
 

--- a/roles/ovirt-collect-logs/tasks/engine.yml
+++ b/roles/ovirt-collect-logs/tasks/engine.yml
@@ -55,8 +55,9 @@
 
     - src: "/var/log/ovn"
       dest: "ovn-logs"
-        - src: "/var/log/openvswitch"
-          dest: "ovs-logs"
+
+    - src: "/var/log/openvswitch"
+      dest: "ovs-logs"
 
   ignore_errors: true
 

--- a/roles/ovirt-collect-logs/tasks/hypervisor.yml
+++ b/roles/ovirt-collect-logs/tasks/hypervisor.yml
@@ -56,8 +56,9 @@
 
     - src: "/var/log/ovn"
       dest: "ovn-logs"
-        - src: "/var/log/openvswitch"
-          dest: "ovs-logs"
+
+    - src: "/var/log/openvswitch"
+      dest: "ovs-logs"
 
   ignore_errors: true
 

--- a/roles/ovirt-collect-logs/tasks/hypervisor.yml
+++ b/roles/ovirt-collect-logs/tasks/hypervisor.yml
@@ -56,6 +56,21 @@
 
   ignore_errors: true
 
+- name: Link ovn and openvswitch logs
+  file:
+    src: "{{ item.src }}"
+    dest: "{{ ovirt_collect_logs_tmp_dir }}/{{ item.dest }}"
+    state: link
+  with_items:
+    -
+      src: "/var/log/ovn"
+      dest: "ovn-logs"
+    -
+      src: "/var/log/openvswitch"
+      dest: "ovs-logs"
+
+  ignore_errors: true
+
 - name: Dump mount
   shell: "mount &> {{ ovirt_collect_logs_tmp_dir }}/mount.txt" # noqa 301 303
   ignore_errors: true

--- a/roles/ovirt-collect-logs/tasks/hypervisor.yml
+++ b/roles/ovirt-collect-logs/tasks/hypervisor.yml
@@ -58,7 +58,7 @@
       dest: "ovn-logs"
 
     - src: "/var/log/openvswitch"
-      dest: "ovs-logs"
+      dest: "openvswitch-logs"
 
   ignore_errors: true
 

--- a/roles/ovirt-collect-logs/tasks/hypervisor.yml
+++ b/roles/ovirt-collect-logs/tasks/hypervisor.yml
@@ -54,20 +54,10 @@
       src: "/var/log/openvswitch/ovsdb-server.log"
       dest: "ovsdb-server.log"
 
-  ignore_errors: true
-
-- name: Link ovn and openvswitch logs
-  file:
-    src: "{{ item.src }}"
-    dest: "{{ ovirt_collect_logs_tmp_dir }}/{{ item.dest }}"
-    state: link
-  with_items:
-    -
-      src: "/var/log/ovn"
+    - src: "/var/log/ovn"
       dest: "ovn-logs"
-    -
-      src: "/var/log/openvswitch"
-      dest: "ovs-logs"
+        - src: "/var/log/openvswitch"
+          dest: "ovs-logs"
 
   ignore_errors: true
 


### PR DESCRIPTION
This change adds collection of OVN/OVS logs from both Ovirt Engine
and hypervisors
This is elementary in order to analyze failures in these components